### PR TITLE
added extra argument to dbquery syscall to avoid magic number

### DIFF
--- a/sys/kern/kern_dbquery.c
+++ b/sys/kern/kern_dbquery.c
@@ -13,7 +13,7 @@ MALLOC_DECLARE(M_DBQUERY); // Declare a new malloc type for our system call
 
 int sys_dbquery (struct thread *td, struct dbquery_args *uap) {
     int error = 0;
-    int space_required = 500;
+    int space_required = 16;
     char *kernel_buffer;
 
     kernel_buffer = (char *)malloc(space_required, M_DBQUERY, M_WAITOK | M_ZERO);
@@ -22,8 +22,7 @@ int sys_dbquery (struct thread *td, struct dbquery_args *uap) {
         return ENOMEM;
     }
 
-    sprintf(kernel_buffer, "Not implemented");
-    kernel_buffer[499] = '\0';
+    sprintf(kernel_buffer, "Not implemented\n");
 
     error = copyout(kernel_buffer, uap->buf, space_required);
 

--- a/sys/kern/syscalls.master
+++ b/sys/kern/syscalls.master
@@ -3337,7 +3337,8 @@
 	}
 589 AUE_NULL STD {
 		int dbquery(
-			_In_z_ const char *query,
+			_In_reads_z(querylen) const char *query,
+			int querylen,
 			_Out_writes_z(reslen) char *buf,
 			int reslen
 		);

--- a/sys/kern/systrace_args.c
+++ b/sys/kern/systrace_args.c
@@ -3456,6 +3456,7 @@ systrace_args(int sysnum, void *params, uint64_t *uarg, int *n_args)
 	case 589: {
 		struct dbquery_args *p = params;
 		uarg[a++] = (intptr_t)p->query; /* const char * */
+		iarg[a++] = p->querylen; /* int */
 		uarg[a++] = (intptr_t)p->buf; /* char * */
 		iarg[a++] = p->reslen; /* int */
 		*n_args = 3;
@@ -9249,9 +9250,12 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			p = "userland const char *";
 			break;
 		case 1:
-			p = "userland char *";
+			p = "int";
 			break;
 		case 2:
+			p = "userland char *";
+			break;
+		case 3:
 			p = "int";
 			break;
 		default:

--- a/sys/sys/sysproto.h
+++ b/sys/sys/sysproto.h
@@ -1876,6 +1876,7 @@ struct helloworld_args {
 };
 struct dbquery_args {
 	char query_l_[PADL_(const char *)]; const char * query; char query_r_[PADR_(const char *)];
+	char querylen_l_[PADL_(int)]; int querylen; char querylen_r_[PADR_(int)];
 	char buf_l_[PADL_(char *)]; char * buf; char buf_r_[PADR_(char *)];
 	char reslen_l_[PADL_(int)]; int reslen; char reslen_r_[PADR_(int)];
 };


### PR DESCRIPTION
Modified the dbquery system call in every file it was necessary so that it can accommodate the size of the input string as an argument, resulting in removing magic number.

The magic number 16 that appears is the size of "Not implemented\n" and is used for the (constant) size of the output string "Not implemented\n".