### PR TITLE
Integrate clang plugin into kernel build

### DIFF
--- a/share/mk/bsd.own.mk
+++ b/share/mk/bsd.own.mk
@@ -154,6 +154,7 @@ __<bsd.own.mk>__:
 
 .if ${MK_CTF} != "no"
 CTFCONVERT_CMD=	${CTFCONVERT} ${CTFFLAGS} ${.TARGET}
+TBLEXTRACT_CMD= /sys/conf/ctf_with_clang_plugin ${.IMPSRC}
 .else
 CTFCONVERT_CMD=
 .endif 

--- a/share/mk/bsd.suffixes.mk
+++ b/share/mk/bsd.suffixes.mk
@@ -10,6 +10,7 @@
 .c.o:
 	${CC} ${STATIC_CFLAGS} ${CFLAGS} -c ${.IMPSRC} -o ${.TARGET}
 	${CTFCONVERT_CMD}
+	${TBLEXTRACT_CMD}
 
 .c.bco:
 	${CC} -emit-llvm ${IR_CFLAGS} -c ${.IMPSRC} -o ${.TARGET}

--- a/share/mk/bsd.suffixes.mk
+++ b/share/mk/bsd.suffixes.mk
@@ -10,7 +10,9 @@
 .c.o:
 	${CC} ${STATIC_CFLAGS} ${CFLAGS} -c ${.IMPSRC} -o ${.TARGET}
 	${CTFCONVERT_CMD}
+.if !empty(WITH_TBLEXTRACT)
 	${TBLEXTRACT_CMD}
+.endif
 
 .c.bco:
 	${CC} -emit-llvm ${IR_CFLAGS} -c ${.IMPSRC} -o ${.TARGET}

--- a/sys/conf/ctf_with_clang_plugin
+++ b/sys/conf/ctf_with_clang_plugin
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+CLANG_PLUGIN_CMD="/usr/local/llvm17/bin/clang -fplugin=/mnt/openbsd_list_macro_printer/build/lib/Release/libopenbsd_list_macro_printer.so -fsyntax-only -fno-builtin"
+KERNEL_CFLAGS="-target aarch64-unknown-freebsd15.0 --sysroot=/usr/obj/usr/src/arm64.aarch64/tmp \
+-B/usr/obj/usr/src/arm64.aarch64/tmp/usr/bin -I/usr/src/sys -I/usr/src/sys/contrib \
+-I/usr/src/include -I/usr/src/contrib/llvm-project/clang/lib/Headers \
+-I/usr/src/sys/contrib/ck -I/usr/src/sys/contrib/ck/src -I/usr/src/sys/contrib/ck/include -I/usr/src/sys/contrib/libfdt \
+-I/usr/obj/usr/src/arm64.aarch64/sys/GENERIC -D_KERNEL -I/usr/src/sys/contrib/xz-embedded/linux/include/linux \
+-I/usr/src/sys/contrib/xz-embedded/freebsd -I/usr/src/sys/contrib/zstd/lib/common \
+-I/usr/src/sys/contrib/openzfs/module/zstd/include -I/usr/local/llvm17/lib/clang/17/include \
+-I/usr/src/sys/crypto/blake2 -I/usr/src/sys/contrib/libsodium/src/libsodium/include \
+-I/usr/src/sys/compat/linuxkpi/common/include -I/usr/src/sys/compat/linuxkpi/dymmy/include \
+-include /usr/obj/usr/src/arm64.aarch64/sys/GENERIC/opt_global.h -nostdinc"
+
+CTFCONVERT="/usr/bin/ctfconvert"
+CTFFLAGS="-L VERSION -g"  
+
+case "$1" in
+  *.c|*.h)
+    echo "Running Clang plugin on $1..."
+    ${CLANG_PLUGIN_CMD} ${KERNEL_CFLAGS} "$1"
+
+    if [ $? -ne 0 ]; then
+      echo "Error running Clang plugin on $1"
+      exit 1
+    fi
+    ;;
+  *.o)
+    echo "Skipping Clang plugin for object file $1..."
+    ;;
+  *)
+    echo "Skipping Clang plugin for non-C/C header file $1..."
+    ;;
+esac
+
+if [ $? -eq 0 ]; then
+  ${CTFCONVERT} ${CTFFLAGS} "$2"
+else
+  echo "Error running Clang plugin"
+  exit 1
+fi

--- a/sys/conf/ctf_with_clang_plugin
+++ b/sys/conf/ctf_with_clang_plugin
@@ -12,17 +12,13 @@ KERNEL_CFLAGS="-target aarch64-unknown-freebsd15.0 --sysroot=/usr/obj/usr/src/ar
 -I/usr/src/sys/compat/linuxkpi/common/include -I/usr/src/sys/compat/linuxkpi/dymmy/include \
 -include /usr/obj/usr/src/arm64.aarch64/sys/GENERIC/opt_global.h -nostdinc"
 
-CTFCONVERT="/usr/bin/ctfconvert"
-CTFFLAGS="-L VERSION -g"  
-
 case "$1" in
   *.c|*.h)
     echo "Running Clang plugin on $1..."
     ${CLANG_PLUGIN_CMD} ${KERNEL_CFLAGS} "$1"
-
+    
     if [ $? -ne 0 ]; then
       echo "Error running Clang plugin on $1"
-      exit 1
     fi
     ;;
   *.o)
@@ -32,10 +28,3 @@ case "$1" in
     echo "Skipping Clang plugin for non-C/C header file $1..."
     ;;
 esac
-
-if [ $? -eq 0 ]; then
-  ${CTFCONVERT} ${CTFFLAGS} "$2"
-else
-  echo "Error running Clang plugin"
-  exit 1
-fi

--- a/sys/conf/kern.pre.mk
+++ b/sys/conf/kern.pre.mk
@@ -309,7 +309,7 @@ FBT_CFLAGS+=	-I$S/cddl/dev/fbt/x86
 FBT_C=		${CC} -c ${FBT_CFLAGS}		${WERROR} ${.IMPSRC}
 
 .if ${MK_CTF} != "no"
-NORMAL_CTFCONVERT=	${CTFCONVERT} ${CTFFLAGS} ${.TARGET}
+NORMAL_CTFCONVERT=	/sys/conf/ctf_with_clang_plugin ${.IMPSRC} ${.TARGET}
 .elif ${MAKE_VERSION} >= 5201111300
 NORMAL_CTFCONVERT=
 .else

--- a/sys/conf/kern.pre.mk
+++ b/sys/conf/kern.pre.mk
@@ -309,7 +309,7 @@ FBT_CFLAGS+=	-I$S/cddl/dev/fbt/x86
 FBT_C=		${CC} -c ${FBT_CFLAGS}		${WERROR} ${.IMPSRC}
 
 .if ${MK_CTF} != "no"
-NORMAL_CTFCONVERT=	/sys/conf/ctf_with_clang_plugin ${.IMPSRC} ${.TARGET}
+NORMAL_CTFCONVERT=	${CTFCONVERT} ${CTFFLAGS} ${.TARGET}
 .elif ${MAKE_VERSION} >= 5201111300
 NORMAL_CTFCONVERT=
 .else


### PR DESCRIPTION
Modify ctf convert macro so that the build runs the clang plugin as well, using a script that filters to only run on C source code files. 