### PR TITLE
Adding seconds in osdb_sample_args

### DIFF
--- a/sys/sys/sysproto.h
+++ b/sys/sys/sysproto.h
@@ -1963,6 +1963,7 @@ struct osdb_column_name_args {
 struct osdb_sample_args {
 	char delay_l_[PADL_(int)]; int delay; char delay_r_[PADR_(int)];
 	char max_l_[PADL_(int)]; int max; char max_r_[PADR_(int)];
+	char seconds_l_[PADL_(int)]; int seconds; char seconds_r_[PADR_(int)];
 };
 struct osdb_snapshot_clear_args {
 	syscallarg_t dummy;


### PR DESCRIPTION
https://github.com/yale-systems/osdb/pull/242 introduced a sampling interval, but the `seconds` field is missing from the syscall arguments, so introducing it